### PR TITLE
nav: Liquid Glass pill + links dropdown, remove nav-back.png

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,13 +23,33 @@
 
 <body>
   <header class="header">
-    <h1 class="site-title">Quartu - Clank's works</h1>
+    <h1 class="site-title">Quartu</h1>
     <nav class="nav">
-      <ul>
+      <ul class="nav-internal">
         <li><a href="#about"><i class="fa-solid fa-address-card"></i><span>about</span></a></li>
         <li><a href="#projects"><i class="fa-solid fa-folder-open"></i><span>portfolio</span></a></li>
         <li><a href="#other"><i class="fa-solid fa-bolt"></i><span>other</span></a></li>
       </ul>
+      <div class="nav-divider"></div>
+      <div class="nav-external">
+        <button class="nav-links-toggle" aria-expanded="false" aria-label="外部リンク一覧">
+          <i class="fa-solid fa-arrow-up-right-from-square"></i><span>links</span>
+        </button>
+        <ul class="nav-links-dropdown">
+          <li><a href="https://www.clank.work/sixsenses/" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>six senses</a></li>
+          <li><a href="https://play.google.com/store/apps/details?id=net.mohyo.works.randomToDoNotes" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>Random ToDo Notes</a></li>
+          <li><a href="https://www.youtube.com/@clank3140" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>YouTube</a></li>
+          <li><a href="https://x.com/clank3140_mo_de/status/1840062420087386158" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>manga</a></li>
+          <li><a href="https://clank.booth.pm/items/6185536" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>BOOTH</a></li>
+          <li><a href="https://www.nicovideo.jp/user/60412547/mylist" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>niconico</a></li>
+          <li><a href="https://suzuri.jp/FruorWorks" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>SUZURI</a></li>
+          <li><a href="https://vrchat.com/home/user/usr_96d22133-b5ea-4b56-b9f1-5ab136d31bbc" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>VRChat</a></li>
+          <li><a href="https://fruor-studio.booth.pm" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>Fruor Studio BOOTH</a></li>
+          <li><a href="https://talto.cc/users/NnACZXCGAUP7USJlLb1cKogWXnZ2" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>TALTO</a></li>
+          <li><a href="https://soundcloud.com/clank3140" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>SoundCloud</a></li>
+          <li><a href="https://note.com/clank3140" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>note</a></li>
+        </ul>
+      </div>
     </nav>
   </header>
 
@@ -181,6 +201,18 @@
   <footer class="footer">
     <p>&copy; 2026 Clank</p>
   </footer>
+
+  <script>
+    const toggle = document.querySelector('.nav-links-toggle');
+    document.addEventListener('click', function(e) {
+      if (toggle.contains(e.target)) {
+        const expanded = toggle.getAttribute('aria-expanded') === 'true';
+        toggle.setAttribute('aria-expanded', String(!expanded));
+      } else {
+        toggle.setAttribute('aria-expanded', 'false');
+      }
+    });
+  </script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -36,18 +36,20 @@
           <i class="fa-solid fa-arrow-up-right-from-square"></i><span>links</span>
         </button>
         <ul class="nav-links-dropdown">
-          <li><a href="https://www.clank.work/sixsenses/" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>six senses</a></li>
-          <li><a href="https://play.google.com/store/apps/details?id=net.mohyo.works.randomToDoNotes" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>Random ToDo Notes</a></li>
-          <li><a href="https://www.youtube.com/@clank3140" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>YouTube</a></li>
-          <li><a href="https://x.com/clank3140_mo_de/status/1840062420087386158" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>manga</a></li>
-          <li><a href="https://clank.booth.pm/items/6185536" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>BOOTH</a></li>
-          <li><a href="https://www.nicovideo.jp/user/60412547/mylist" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>niconico</a></li>
-          <li><a href="https://suzuri.jp/FruorWorks" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>SUZURI</a></li>
-          <li><a href="https://vrchat.com/home/user/usr_96d22133-b5ea-4b56-b9f1-5ab136d31bbc" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>VRChat</a></li>
-          <li><a href="https://fruor-studio.booth.pm" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>Fruor Studio BOOTH</a></li>
-          <li><a href="https://talto.cc/users/NnACZXCGAUP7USJlLb1cKogWXnZ2" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>TALTO</a></li>
-          <li><a href="https://soundcloud.com/clank3140" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>SoundCloud</a></li>
-          <li><a href="https://note.com/clank3140" target="_blank" rel="noopener noreferrer"><i class="fa-solid fa-arrow-up-right-from-square"></i>note</a></li>
+          <li><a href="https://www.youtube.com/@clank3140" target="_blank" rel="noopener noreferrer"><i
+                class="fa-solid fa-arrow-up-right-from-square"></i>YouTube</a></li>
+          <li><a href="https://www.nicovideo.jp/user/60412547/mylist" target="_blank" rel="noopener noreferrer"><i
+                class="fa-solid fa-arrow-up-right-from-square"></i>niconico</a></li>
+          <li><a href="https://note.com/clank3140" target="_blank" rel="noopener noreferrer"><i
+                class="fa-solid fa-arrow-up-right-from-square"></i>note</a></li>
+          <li><a href="https://clank.booth.pm/items/6185536" target="_blank" rel="noopener noreferrer"><i
+                class="fa-solid fa-arrow-up-right-from-square"></i>BOOTH</a></li>
+          <li><a href="https://suzuri.jp/FruorWorks" target="_blank" rel="noopener noreferrer"><i
+                class="fa-solid fa-arrow-up-right-from-square"></i>SUZURI</a></li>
+          <li><a href="https://talto.cc/users/NnACZXCGAUP7USJlLb1cKogWXnZ2" target="_blank" rel="noopener noreferrer"><i
+                class="fa-solid fa-arrow-up-right-from-square"></i>TALTO</a></li>
+          <li><a href="https://soundcloud.com/clank3140" target="_blank" rel="noopener noreferrer"><i
+                class="fa-solid fa-arrow-up-right-from-square"></i>SoundCloud</a></li>
         </ul>
       </div>
     </nav>
@@ -204,7 +206,7 @@
 
   <script>
     const toggle = document.querySelector('.nav-links-toggle');
-    document.addEventListener('click', function(e) {
+    document.addEventListener('click', function (e) {
       if (toggle.contains(e.target)) {
         const expanded = toggle.getAttribute('aria-expanded') === 'true';
         toggle.setAttribute('aria-expanded', String(!expanded));

--- a/styles.css
+++ b/styles.css
@@ -89,87 +89,174 @@ p {
 }
 
 .header {
-    text-align: center;
-    width: 100%;
-    transition: 1s;
-    background-color: rgba(0, 0, 0, 0.3);
-    padding: 20px;
-    position: relative;
-    z-index: 1;
-}
-
-.header::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: url(images/nav-back.png);
-    background-size: cover;
-    background-position: center;
-    opacity: 0.5;
-    z-index: -1;
-    transition: 1s;
-}
-
-.header:hover::before {
-    background-position: bottom;
-    opacity: 0.7;
+    position: sticky;
+    top: 16px;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: fit-content;
+    max-width: calc(100% - 32px);
+    margin: 16px auto 0;
+    padding: 10px 20px;
+    background: rgba(255, 255, 255, 0.06);
+    backdrop-filter: blur(20px) saturate(160%);
+    -webkit-backdrop-filter: blur(20px) saturate(160%);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    box-shadow:
+        0 8px 32px rgba(0, 0, 0, 0.4),
+        inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .site-title {
-    position: relative;
-    z-index: 2;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.75);
+    margin: 0;
+    padding: 0 4px;
+    white-space: nowrap;
+    letter-spacing: 0.02em;
 }
 
 .nav {
+    display: flex;
+    align-items: center;
+    gap: 4px;
     position: relative;
-    z-index: 2;
 }
 
-.nav ul {
+.nav-internal {
     list-style: none;
     padding: 0;
+    margin: 0;
     display: flex;
-    justify-content: center;
-    gap: 100px;
-    flex-wrap: wrap;
+    align-items: center;
+    gap: 0;
 }
 
-.nav a {
+.nav-divider {
+    width: 1px;
+    height: 20px;
+    background: rgba(255, 255, 255, 0.2);
+    margin: 0 8px;
+    flex-shrink: 0;
+}
+
+.nav-internal a {
     color: #ff00ff;
     text-decoration: none;
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 8px;
     position: relative;
-    padding: 5px;
+    transition: background 0.2s;
 }
 
-.nav a i {
-    font-size: 1.2em;
-    transition: transform 0.3s ease;
+.nav-internal a:hover {
+    background: rgba(255, 0, 255, 0.1);
+    color: #ff00ff;
 }
 
-.nav a span {
+.nav-internal a i {
+    font-size: 1.1em;
+    flex-shrink: 0;
+}
+
+.nav-internal a span {
     display: inline-block;
     opacity: 0;
-    transform: translateX(-10px);
-    transition: all 0.15s ease;
-    position: absolute;
-    left: 100%;
+    transform: translateX(-6px);
+    transition: opacity 0.15s ease, transform 0.15s ease;
     white-space: nowrap;
+    font-size: 0.85rem;
     pointer-events: none;
+    position: absolute;
+    left: calc(100% - 4px);
 }
 
-.nav a:hover i {
-    transform: scale(1.1);
-}
-
-.nav a:hover span {
+.nav-internal a:hover span {
     opacity: 1;
-    transform: translateX(5px);
+    transform: translateX(0);
+}
+
+.nav-external {
+    position: relative;
+}
+
+.nav-links-toggle {
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.7);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    font-family: inherit;
+    transition: background 0.2s, color 0.2s;
+    white-space: nowrap;
+}
+
+.nav-links-toggle:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: #ffffff;
+}
+
+.nav-links-toggle i {
+    font-size: 0.9em;
+}
+
+.nav-links-dropdown {
+    display: none;
+    position: absolute;
+    top: calc(100% + 12px);
+    right: -8px;
+    background: rgba(15, 15, 25, 0.88);
+    backdrop-filter: blur(24px) saturate(160%);
+    -webkit-backdrop-filter: blur(24px) saturate(160%);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 16px;
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.55), inset 0 1px 0 rgba(255, 255, 255, 0.07);
+    padding: 10px;
+    list-style: none;
+    margin: 0;
+    grid-template-columns: 1fr 1fr;
+    gap: 4px;
+    min-width: 340px;
+    z-index: 200;
+}
+
+.nav-links-toggle[aria-expanded="true"] + .nav-links-dropdown {
+    display: grid;
+}
+
+.nav-links-dropdown a {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 10px;
+    border-radius: 8px;
+    color: rgba(255, 255, 255, 0.7);
+    text-decoration: none;
+    font-size: 0.82rem;
+    white-space: nowrap;
+    transition: background 0.2s, color 0.2s;
+}
+
+.nav-links-dropdown a:hover {
+    background: rgba(255, 255, 255, 0.08);
+    color: #ffffff;
+}
+
+.nav-links-dropdown a i {
+    font-size: 0.75em;
+    opacity: 0.5;
+    flex-shrink: 0;
 }
 
 .content {
@@ -349,41 +436,61 @@ p.social-icon{
 /* スマートフォン向けのスタイル調整 */
 @media screen and (max-width: 768px) {
     .header {
-        padding: 15px 10px;
+        width: calc(100% - 24px);
+        border-radius: 20px;
+        padding: 10px 14px;
+        gap: 8px;
+        flex-wrap: wrap;
+        justify-content: center;
     }
 
     .site-title {
-        font-size: 1.5rem;
-        margin: 0 0 15px 0;
+        font-size: 0.8rem;
+    }
+
+    .nav {
+        gap: 2px;
+        flex-wrap: wrap;
+        justify-content: center;
     }
 
     /* モバイルはテキストを常時表示 */
-    .nav ul {
+    .nav-internal {
         gap: 0;
-        justify-content: space-around;
-        width: 100%;
     }
 
-    .nav a {
+    .nav-internal a {
         flex-direction: column;
         align-items: center;
-        gap: 4px;
-        padding: 8px 12px;
-        position: static;
+        gap: 3px;
+        padding: 8px 10px;
     }
 
-    .nav a i {
-        font-size: 1.3em;
+    .nav-internal a i {
+        font-size: 1.2em;
     }
 
-    .nav a span {
+    .nav-internal a span {
         opacity: 1;
         transform: none;
         position: static;
-        font-size: 0.75rem;
-        white-space: nowrap;
+        font-size: 0.72rem;
         pointer-events: auto;
-        color: #ff00ff;
+    }
+
+    .nav-links-toggle {
+        flex-direction: column;
+        gap: 3px;
+        padding: 8px 10px;
+        font-size: 0.72rem;
+    }
+
+    .nav-links-dropdown {
+        right: auto;
+        left: 50%;
+        transform: translateX(-50%);
+        min-width: calc(100vw - 40px);
+        grid-template-columns: 1fr 1fr;
     }
 
     .content {

--- a/styles.css
+++ b/styles.css
@@ -2,8 +2,7 @@ body {
     font-family: 'Noto Sans JP', Arial, sans-serif;
     margin: 0;
     padding: 0;
-    background-color: #121212;
-    background: linear-gradient(135deg, #0a1520 0%, #121212 50%, #1e0a14 100%) fixed;
+    background-color: #0e0e12;
     color: #ffffff;
     display: flex;
     flex-direction: column;
@@ -49,7 +48,7 @@ h2::after {
     bottom: 0;
     width: 100%;
     height: 3px;
-    background: linear-gradient(to right, #FF6B6B, #4ECDC4);
+    background: #4ECDC4;
 }
 
 h3 {
@@ -57,7 +56,7 @@ h3 {
     font-size: 1.8rem;
     font-weight: 600;
     padding: 0.3em 0.5em;
-    border-left: 5px solid #474747;
+    border-left: 5px solid rgba(78, 205, 196, 0.45);
     background: rgb(155 155 155 / 10%);
     margin: 2em 0 1em;
     box-shadow: 2px 2px 10px rgba(0,0,0,0.1);
@@ -144,7 +143,7 @@ p {
 }
 
 .nav-internal a {
-    color: #ff00ff;
+    color: #4ECDC4;
     text-decoration: none;
     display: flex;
     flex-direction: column;
@@ -156,8 +155,8 @@ p {
 }
 
 .nav-internal a:hover {
-    background: rgba(255, 0, 255, 0.1);
-    color: #ff00ff;
+    background: rgba(78, 205, 196, 0.12);
+    color: #4ECDC4;
 }
 
 .nav-internal a i {
@@ -332,13 +331,13 @@ section {
 }
 
 a {
-    color: #ffff00;
+    color: #4ECDC4;
     text-decoration: underline;
     transition: all 0.3s ease;
 }
 
 a:hover {
-    color: #00ffff;
+    color: #ffffff;
 }
 
 a.navbar-brand:hover {
@@ -370,7 +369,7 @@ a.navbar-brand:hover {
     font-size: 1.5rem;
     font-weight: 600;
     margin: 1rem 0;
-    background: linear-gradient(45deg, #FF6B6B, #4ECDC4);
+    background: linear-gradient(45deg, #4ECDC4, #7edcd8);
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
 }

--- a/styles.css
+++ b/styles.css
@@ -147,11 +147,11 @@ p {
     color: #ff00ff;
     text-decoration: none;
     display: flex;
+    flex-direction: column;
     align-items: center;
-    gap: 6px;
-    padding: 6px 10px;
+    gap: 3px;
+    padding: 6px 12px;
     border-radius: 8px;
-    position: relative;
     transition: background 0.2s;
 }
 
@@ -166,20 +166,12 @@ p {
 }
 
 .nav-internal a span {
-    display: inline-block;
-    opacity: 0;
-    transform: translateX(-6px);
-    transition: opacity 0.15s ease, transform 0.15s ease;
-    white-space: nowrap;
-    font-size: 0.85rem;
-    pointer-events: none;
-    position: absolute;
-    left: calc(100% - 4px);
-}
-
-.nav-internal a:hover span {
     opacity: 1;
-    transform: translateX(0);
+    transform: none;
+    position: static;
+    white-space: nowrap;
+    font-size: 0.72rem;
+    pointer-events: auto;
 }
 
 .nav-external {
@@ -454,28 +446,12 @@ p.social-icon{
         justify-content: center;
     }
 
-    /* モバイルはテキストを常時表示 */
     .nav-internal {
         gap: 0;
     }
 
     .nav-internal a {
-        flex-direction: column;
-        align-items: center;
-        gap: 3px;
         padding: 8px 10px;
-    }
-
-    .nav-internal a i {
-        font-size: 1.2em;
-    }
-
-    .nav-internal a span {
-        opacity: 1;
-        transform: none;
-        position: static;
-        font-size: 0.72rem;
-        pointer-events: auto;
     }
 
     .nav-links-toggle {

--- a/styles.css
+++ b/styles.css
@@ -35,7 +35,7 @@ h2 {
     background: linear-gradient(45deg, rgb(144 144 144 / 50%), rgb(51 51 51 / 50%));
     padding: 0.5em 1em;
     border-radius: 8px;
-    box-shadow: 0 4px 15px rgba(0,0,0,0.2);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
     margin: 2.5em 0 1.5em;
     position: relative;
     overflow: hidden;
@@ -59,7 +59,7 @@ h3 {
     border-left: 5px solid rgba(78, 205, 196, 0.45);
     background: rgb(155 155 155 / 10%);
     margin: 2em 0 1em;
-    box-shadow: 2px 2px 10px rgba(0,0,0,0.1);
+    box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.1);
 }
 
 p {
@@ -67,7 +67,7 @@ p {
     line-height: 1.6;
 }
 
-#about h2{
+#about h2 {
     margin-top: 0;
 }
 
@@ -78,12 +78,12 @@ p {
     margin: 1.2em 0;
 }
 
-.title span{
+.title span {
     background-color: #222;
     text-decoration: none;
 }
 
-.title i{
+.title i {
     margin-left: 1rem;
 }
 
@@ -222,7 +222,7 @@ p {
     z-index: 200;
 }
 
-.nav-links-toggle[aria-expanded="true"] + .nav-links-dropdown {
+.nav-links-toggle[aria-expanded="true"]+.nav-links-dropdown {
     display: grid;
 }
 
@@ -362,16 +362,14 @@ a.navbar-brand:hover {
     height: 150px;
     border-radius: 25%;
     object-fit: cover;
-    box-shadow: 0 4px 15px rgba(0,0,0,0.2);
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
 }
 
 .profile-name {
     font-size: 1.5rem;
-    font-weight: 600;
+    font-weight: 700;
     margin: 1rem 0;
-    background: linear-gradient(45deg, #4ECDC4, #7edcd8);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
+    color: #ffffff
 }
 
 .profile-description {
@@ -405,7 +403,7 @@ a.navbar-brand:hover {
     color: #ffffff;
 }
 
-p.social-icon{
+p.social-icon {
     margin: 0;
 }
 

--- a/styles.css
+++ b/styles.css
@@ -205,7 +205,7 @@ p {
 .nav-links-dropdown {
     display: none;
     position: absolute;
-    top: calc(100% + 12px);
+    top: calc(100% + 30px);
     right: -8px;
     background: rgba(15, 15, 25, 0.88);
     backdrop-filter: blur(24px) saturate(160%);

--- a/styles.css
+++ b/styles.css
@@ -459,10 +459,12 @@ p.social-icon {
     }
 
     .nav-links-dropdown {
-        right: auto;
-        left: 50%;
-        transform: translateX(-50%);
-        min-width: calc(100vw - 40px);
+        position: fixed;
+        top: 80px;
+        left: 12px;
+        right: 12px;
+        transform: none;
+        min-width: unset;
         grid-template-columns: 1fr 1fr;
     }
 


### PR DESCRIPTION
フローティング pill 型ナビバーに刷新。backdrop-filter で Liquid Glass 効果を適用し、 nav-back.png への依存を除去。portfolio の外部リンク 12 件を links ドロップダウンに集約し、 ページ内リンク（マゼンタ）と外部リンク（白系＋矢印アイコン）を視覚的に区別。
h1.site-title は pill 左端に小テキストとして残し SEO を維持。

https://claude.ai/code/session_01EzhuosoZS1taqBtBaM5QH1